### PR TITLE
doc: fix README to direct 1.4.1 image building instructions to old page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,9 @@ Building Images
 The Dockerfiles in this repository are intended to be used for building Docker images to run inference endpoints on `Amazon SageMaker <https://aws.amazon.com/documentation/sagemaker/>`__.
 
 The current master branch of this repository contains Dockerfiles and support code for MXNet versions 1.4.0 and higher. For previous versions, see `SageMaker MXNet container <https://github.com/aws/sagemaker-mxnet-container>`__.
-The instructions in this version of this README are for MXNet 1.4.1 and higher. For MXNet 1.4.0, see `the previous version of this file <https://github.com/aws/sagemaker-mxnet-serving-container/blob/5ec2328c20612c2aa3474c978e459b4bca033f27/README.rst>`__.
+The instructions in this version of this README are for MXNet 1.6.0 and higher. For MXNet 1.4.1 and lower, see `the previous version of this file <https://github.com/aws/sagemaker-mxnet-serving-container/blob/5ec2328c20612c2aa3474c978e459b4bca033f27/README.rst>`__.
 
-The integration tests expect the Docker images to be tagged as ``preprod-mxnet-serving:<tag>``, where ``<tag>`` looks like <mxnet_version>-<processor>-<python_version> (e.g. 1.4.1-cpu-py3).
+The integration tests expect the Docker images to be tagged as ``preprod-mxnet-serving:<tag>``, where ``<tag>`` looks like <mxnet_version>-<processor>-<python_version> (e.g. 1.6.0-cpu-py3).
 
 Example commands for building images:
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Building Images
 The Dockerfiles in this repository are intended to be used for building Docker images to run inference endpoints on `Amazon SageMaker <https://aws.amazon.com/documentation/sagemaker/>`__.
 
 The current master branch of this repository contains Dockerfiles and support code for MXNet versions 1.4.0 and higher. For previous versions, see `SageMaker MXNet container <https://github.com/aws/sagemaker-mxnet-container>`__.
-The instructions in this version of this README are for MXNet 1.6.0 and higher. For MXNet 1.4.1 and lower, see `the previous version of this file <https://github.com/aws/sagemaker-mxnet-serving-container/blob/5ec2328c20612c2aa3474c978e459b4bca033f27/README.rst>`__.
+The instructions in this version of this README are for MXNet 1.5.1 and higher. For MXNet 1.4.1 and lower, see `the previous version of this file <https://github.com/aws/sagemaker-mxnet-serving-container/blob/5ec2328c20612c2aa3474c978e459b4bca033f27/README.rst>`__.
 
 The integration tests expect the Docker images to be tagged as ``preprod-mxnet-serving:<tag>``, where ``<tag>`` looks like <mxnet_version>-<processor>-<python_version> (e.g. 1.6.0-cpu-py3).
 


### PR DESCRIPTION
*Issue #, if available:*
#123 

*Description of changes:*
version 1.4.1 docker images still requires installing sagemaker_mxnet_serving_container from source: https://github.com/aws/sagemaker-mxnet-serving-container/blob/master/docker/1.4.1/py3/Dockerfile.cpu#L40

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
