### PR TITLE
infra: move GPU tests to buildspec-gpu.yml

### DIFF
--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -29,8 +29,8 @@ phases:
 
       # TODO: remove these debugging commands
       - df -H
+      - du -h
       - docker info
-      - lsmod | grep overlay
 
       # build GPU images
       - python3.6 setup.py sdist

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd --storage-opt dm.basesize=20G
+      - start-dockerd
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
@@ -30,6 +30,8 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
+      - echo "Docker daemon configuration:"
+      - cat /etc/docker/daemon.json
 
       # build GPU images
       - python3.6 setup.py sdist

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -31,10 +31,10 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
-      - sudo systemctl stop docker
+      - systemctl stop docker
       - echo $DAEMON_JSON > /etc/docker/daemon.json
       - cat /etc/docker/daemon.json
-      - sudo systemctl start docker
+      - systemctl start docker
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd --storage-driver devicemapper --storage-opt dm.basesize=20G
+      - start-dockerd
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
@@ -29,6 +29,12 @@ phases:
 
       # TODO: remove these debugging commands
       - df -H
+      - docker info
+      - systemctl stop docker
+      - daemon_json = '{"storage-driver": "overlay2", "storage-opts": [ "overlay2.size=20G" ]}'
+      - echo $daemon_json > /etc/docker/daemon.json
+      - cat /etc/docker/daemon.json
+      - systemctl start docker
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd --storage-opt overlay2.size=20G
+      - dockerd --storage-driver devicemapper --storage-opt dm.basesize=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -27,6 +27,13 @@ phases:
       # define tags
       - DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID"
 
+      # TODO: remove these debugging commands
+      - df -H
+      - du -d1 -h /var/lib/docker/containers | sort -h
+      - docker system prune
+      - df -H
+      - du -d1 -h /var/lib/docker/containers | sort -h
+
       # build GPU images
       - python3.6 setup.py sdist
       - build_dir="test/container/$FRAMEWORK_VERSION"

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -31,10 +31,10 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
-      - systemctl stop docker
+      - service docker stop
       - echo $DAEMON_JSON > /etc/docker/daemon.json
       - cat /etc/docker/daemon.json
-      - systemctl start docker
+      - service docker stop
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,8 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd --storage-driver devicemapper --storage-opt --dm.basesize=20G
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver overlay2 --storage-opt overlay2.size=20G&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -1,0 +1,52 @@
+version: 0.2
+
+env:
+  variables:
+    FRAMEWORK_VERSION: '1.6.0'
+    EIA_FRAMEWORK_VERSION: '1.4.1'
+    GPU_INSTANCE_TYPE: 'ml.p2.xlarge'
+    EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
+    ECR_REPO: 'sagemaker-test'
+    DLC_ACCOUNT: '763104351884'
+    SETUP_FILE: 'setup_cmds.sh'
+    SETUP_CMDS: '#!/bin/bash\npython3.6 -m pip install --upgrade pip\npython3.6 -m pip install -U -e .\npython3.6 -m pip install -U -e .[test]'
+
+phases:
+  pre_build:
+    commands:
+      - start-dockerd
+      - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
+      - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
+      - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
+      - BUILD_ID="$(echo $CODEBUILD_BUILD_ID | sed -e 's/:/-/g')"
+      - echo 'Pull request number:' $PR_NUM '. No value means this build is not from pull request.'
+
+  build:
+    commands:
+      - TOX_PARALLEL_NO_SPINNER=1
+      - PY_COLORS=0
+
+      # define tags
+      - DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID"
+
+      # build GPU images
+      - python3.6 setup.py sdist
+      - build_dir="test/container/$FRAMEWORK_VERSION"
+      - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
+      - docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .
+      # push images to ECR
+      - $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
+      - docker push $PREPROD_IMAGE:$DLC_GPU_TAG
+
+      # run GPU local integration tests
+      - printf "$SETUP_CMDS" > $SETUP_FILE
+      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
+
+      # run GPU sagemaker integration tests
+      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
+
+    finally:
+      # remove ECR image
+      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_GPU_TAG

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -34,7 +34,7 @@ phases:
       - service docker stop
       - echo $DAEMON_JSON > /etc/docker/daemon.json
       - cat /etc/docker/daemon.json
-      - service docker stop
+      - service docker start
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -30,18 +30,18 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
-      - echo "Docker daemon configuration:"
+      - sudo systemctl stop docker
+      - daemon_json = '{"storage-driver": "overlay2"}'
+      - echo $daemon_json > /etc/docker/daemon.json
       - cat /etc/docker/daemon.json
+      - sudo systemctl start docker
+      - docker info
 
       # build GPU images
       - python3.6 setup.py sdist
       - build_dir="test/container/$FRAMEWORK_VERSION"
       - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
       - docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .
-
-      # TODO: remove these debugging commands
-      - df -H
-      - docker info
 
       # push images to ECR
       - $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -8,7 +8,6 @@ env:
     EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
     ECR_REPO: 'sagemaker-test'
     DLC_ACCOUNT: '763104351884'
-    DAEMON_JSON: '{"storage-driver": "overlay2", "storage-opts": [ "overlay2.size=20G" ]}'
 
 phases:
   pre_build:
@@ -31,11 +30,7 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
-      - service docker stop
-      - echo $DAEMON_JSON > /etc/docker/daemon.json
-      - cat /etc/docker/daemon.json
-      - service docker start
-      - docker info
+      - lsmod | grep overlay
 
       # build GPU images
       - python3.6 setup.py sdist

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - start-dockerd
+      - dockerd --storage-driver overlay2 --storage-opt overlay2.size=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
@@ -29,10 +29,6 @@ phases:
 
       # TODO: remove these debugging commands
       - df -H
-      - du -h
-      - docker info
-      - service docker stop
-      - dockerd --storage-driver overlay2 --storage-opt overlay2.size=20G
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - start-dockerd
+      - dockerd -s overlay2 --storage-opt overlay2.size=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
@@ -29,12 +29,6 @@ phases:
 
       # TODO: remove these debugging commands
       - df -H
-      - docker info
-      - sudo systemctl stop docker
-      - daemon_json = '{"storage-driver": "overlay2"}'
-      - echo $daemon_json > /etc/docker/daemon.json
-      - cat /etc/docker/daemon.json
-      - sudo systemctl start docker
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -31,6 +31,9 @@ phases:
       - df -H
       - du -h
       - docker info
+      - service docker stop
+      - dockerd --storage-driver overlay2 --storage-opt overlay2.size=20G
+      - docker info
 
       # build GPU images
       - python3.6 setup.py sdist

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -30,7 +30,7 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - du -d1 -h /var/lib/docker/containers | sort -h
-      - docker system prune
+      - docker system prune --volumes --force
       - df -H
       - du -d1 -h /var/lib/docker/containers | sort -h
 

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,9 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - which dockerd
-      - nohup dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver overlay2 --storage-opt overlay2.size=20G&
-      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+      - start-dockerd
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -8,8 +8,6 @@ env:
     EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
     ECR_REPO: 'sagemaker-test'
     DLC_ACCOUNT: '763104351884'
-    SETUP_FILE: 'setup_cmds.sh'
-    SETUP_CMDS: '#!/bin/bash\npython3.6 -m pip install --upgrade pip\npython3.6 -m pip install -U -e .\npython3.6 -m pip install -U -e .[test]'
 
 phases:
   pre_build:
@@ -39,7 +37,6 @@ phases:
       - docker push $PREPROD_IMAGE:$DLC_GPU_TAG
 
       # run GPU local integration tests
-      - printf "$SETUP_CMDS" > $SETUP_FILE
       - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
 

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd --storage-driver overlay2 --storage-opt overlay2.size=20G
+      - dockerd --storage-driver devicemapper --storage-opt --dm.basesize=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - dockerd -s overlay2 --storage-opt overlay2.size=20G
+      - dockerd --storage-opt overlay2.size=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -8,6 +8,7 @@ env:
     EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
     ECR_REPO: 'sagemaker-test'
     DLC_ACCOUNT: '763104351884'
+    DAEMON_JSON: '{"storage-driver": "overlay2", "storage-opts": [ "overlay2.size=20G" ]}'
 
 phases:
   pre_build:
@@ -30,11 +31,10 @@ phases:
       # TODO: remove these debugging commands
       - df -H
       - docker info
-      - systemctl stop docker
-      - daemon_json = '{"storage-driver": "overlay2", "storage-opts": [ "overlay2.size=20G" ]}'
-      - echo $daemon_json > /etc/docker/daemon.json
+      - sudo systemctl stop docker
+      - echo $DAEMON_JSON > /etc/docker/daemon.json
       - cat /etc/docker/daemon.json
-      - systemctl start docker
+      - sudo systemctl start docker
       - docker info
 
       # build GPU images

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,7 @@ env:
 phases:
   pre_build:
     commands:
-      - start-dockerd
+      - dockerd --storage-opt dm.basesize=20G
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
@@ -29,16 +29,18 @@ phases:
 
       # TODO: remove these debugging commands
       - df -H
-      - du -d1 -h /var/lib/docker/containers | sort -h
-      - docker system prune --volumes --force
-      - df -H
-      - du -d1 -h /var/lib/docker/containers | sort -h
+      - docker info
 
       # build GPU images
       - python3.6 setup.py sdist
       - build_dir="test/container/$FRAMEWORK_VERSION"
       - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
       - docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .
+
+      # TODO: remove these debugging commands
+      - df -H
+      - docker info
+
       # push images to ECR
       - $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
       - docker push $PREPROD_IMAGE:$DLC_GPU_TAG

--- a/buildspec-gpu.yml
+++ b/buildspec-gpu.yml
@@ -12,7 +12,8 @@ env:
 phases:
   pre_build:
     commands:
-      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver overlay2 --storage-opt overlay2.size=20G&
+      - which dockerd
+      - nohup dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver overlay2 --storage-opt overlay2.size=20G&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
       - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,10 +5,8 @@ env:
     FRAMEWORK_VERSION: '1.6.0'
     EIA_FRAMEWORK_VERSION: '1.4.1'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
-    GPU_INSTANCE_TYPE: 'ml.p2.xlarge'
     EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
     ECR_REPO: 'sagemaker-test'
-    GITHUB_REPO: 'sagemaker-mxnet-serving-container'
     DLC_ACCOUNT: '763104351884'
     SETUP_FILE: 'setup_cmds.sh'
     SETUP_CMDS: '#!/bin/bash\npython3.6 -m pip install --upgrade pip\npython3.6 -m pip install -U -e .\npython3.6 -m pip install -U -e .[test]'
@@ -37,7 +35,6 @@ phases:
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"
       - DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID"
-      - DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID"
       - DLC_EIA_TAG="$EIA_FRAMEWORK_VERSION-dlc-eia-$BUILD_ID"
 
       # run local CPU integration tests (build and push the image to ECR repo)
@@ -46,47 +43,16 @@ phases:
       - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --build-image --push-image --dockerfile-type dlc.cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
 
-      # launch remote GPU instance
-      - prefix='ml.'
-      - instance_type=${GPU_INSTANCE_TYPE#"$prefix"}
-      - create-key-pair
-      - launch-ec2-instance --instance-type $instance_type --ami-name dlami-ubuntu
-
-      # build GPU images because they are too big and take too long to build as part of the test
-      - python3.6 setup.py sdist
-      - build_dir="test/container/$FRAMEWORK_VERSION"
-      - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
-      - docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .
-      # push images to ECR
-      - $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
-      - docker push $PREPROD_IMAGE:$DLC_GPU_TAG
-
-      # run GPU local integration tests
-      - printf "$SETUP_CMDS" > $SETUP_FILE
-      - dlc_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
-      - test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$dlc_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\""
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
-
       # run CPU sagemaker integration tests
       - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $GENERIC_CPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
       - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
-
-      # run GPU sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
-
       # run EIA tests
       - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py --build-image --push-image --dockerfile-type dlc.eia --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $EIA_FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_EIA_TAG  --accelerator-type $EI_ACCELERATOR_TYPE"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml" "artifacts/*"
 
     finally:
-      # shut down remote GPU instance
-      - cleanup-gpu-instances
-      - cleanup-key-pairs
-
       # remove ECR image
       - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$GENERIC_CPU_TAG
       - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_CPU_TAG
-      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_GPU_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,8 +8,6 @@ env:
     EI_ACCELERATOR_TYPE: 'ml.eia1.medium'
     ECR_REPO: 'sagemaker-test'
     DLC_ACCOUNT: '763104351884'
-    SETUP_FILE: 'setup_cmds.sh'
-    SETUP_CMDS: '#!/bin/bash\npython3.6 -m pip install --upgrade pip\npython3.6 -m pip install -U -e .\npython3.6 -m pip install -U -e .[test]'
 
 phases:
   pre_build:


### PR DESCRIPTION
*Description of changes:*
- GPU builds have been set up using CodeBuild instead of a remote GPU EC2 instance.
- This PR moves GPU tests to a separate buildspec used by the CodeBuild GPU build.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
