### PR TITLE
change: drop py27, add py38 support

### DIFF
--- a/.coveragerc_py38
+++ b/.coveragerc_py38
@@ -5,13 +5,13 @@ timid = True
 [report]
 exclude_lines =
     pragma: no cover
-    pragma: py2 no cover
-    if six.PY3
-    elif six.PY3
+    pragma: py3 no cover
+    if six.PY2
+    elif six.PY2
 
 partial_branches =
     pragma: no cover
-    pragma: py2 no cover
+    pragma: py3 no cover
     if six.PY3
     elif six.PY3
 

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36,py37 -- test/unit
+        tox -e py36,py37,py38 -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,7 +32,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py36,py37 test/unit
+      - tox -e py36,py37,py38 test/unit
 
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"


### PR DESCRIPTION
*Issue #, if available:*
buildspec-release tests on py27 but some dependent libraries are not maintaining py27 anymore

*Description of changes:*
drop py27 and add py38 support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
