### PR TITLE
Bump sm inference toolkit version to 1.5.7

### DIFF
--- a/docker/1.5.1/py2/Dockerfile.eia
+++ b/docker/1.5.1/py2/Dockerfile.eia
@@ -4,7 +4,7 @@ LABEL maintainer="Amazon AI"
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG PYTHON=python
 ARG HEALTH_CHECK_VERSION=1.6.3
 
@@ -45,7 +45,7 @@ RUN pip install --no-cache-dir --upgrade \
 
 RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.5.1-py2.py3-none-manylinux1_x86_64.whl \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     # setuptools<45.0.0 because support for py2 stops with 45.0.0
     # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
@@ -71,4 +71,4 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
 EXPOSE 8080 8081
 ENV TEMP=/home/model-server/tmp
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.5.1/py3/Dockerfile.eia
+++ b/docker/1.5.1/py3/Dockerfile.eia
@@ -4,7 +4,7 @@ LABEL maintainer="Amazon AI"
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG PYTHON=python3
 ARG PYTHON_VERSION=3.6.8
 ARG HEALTH_CHECK_VERSION=1.6.3
@@ -66,7 +66,7 @@ RUN pip install --no-cache-dir --upgrade \
 
 RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.5.1-py2.py3-none-manylinux1_x86_64.whl \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     numpy==1.17.4 \
     onnx==1.4.1 \
@@ -112,4 +112,4 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
 EXPOSE 8080 8081
 ENV TEMP=/home/model-server/tmp
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -9,7 +9,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 # https://docs.aws.amazon.com/sagemaker/latest/dg/build-multi-model-build-container.html
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 ARG PYTHON=python
 ARG PYTHON_PIP=python-pip
@@ -53,7 +53,7 @@ RUN ${PIP} install --no-cache-dir \
     # setuptools<45.0.0 because support for py2 stops with 45.0.0
     # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
     "setuptools<45.0.0" \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     numpy==1.16.5 \
     onnx==1.4.1 \
@@ -77,4 +77,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/aws-mxnet-1.6.0/license.txt -
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -6,7 +6,7 @@ LABEL maintainer="Amazon AI"
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_cu101mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 ARG PYTHON=python
 ARG PYTHON_PIP=python-pip
@@ -50,7 +50,7 @@ RUN ${PIP} install --no-cache-dir \
     # setuptools<45.0.0 because support for py2 stops with 45.0.0
     # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
     "setuptools<45.0.0" \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     numpy==1.16.5 \
     onnx==1.4.1 \
@@ -74,4 +74,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/aws-mxnet-1.6.0/license.txt -
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -9,7 +9,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 # https://docs.aws.amazon.com/sagemaker/latest/dg/build-multi-model-build-container.html
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 ARG PYTHON=python3
 ARG PYTHON_PIP=python3-pip
@@ -71,7 +71,7 @@ RUN ${PIP} install --no-cache-dir \
     ${MX_URL} \
     git+git://github.com/dmlc/gluon-nlp.git@v0.9.0 \
     gluoncv==0.6.0 \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     numpy==1.17.4 \
     onnx==1.4.1 \
@@ -95,4 +95,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/aws-mxnet-1.6.0/license.txt -
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -6,7 +6,7 @@ LABEL maintainer="Amazon AI"
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_cu101mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 ARG PYTHON=python3
 ARG PYTHON_PIP=python3-pip
@@ -68,7 +68,7 @@ RUN ${PIP} install --no-cache-dir \
     ${MX_URL} \
     git+git://github.com/dmlc/gluon-nlp.git@v0.9.0 \
     gluoncv==0.6.0 \
-    mxnet-model-server==$MMS_VERSION \
+    multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     numpy==1.17.4 \
     onnx==1.4.1 \
@@ -92,4 +92,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/aws-mxnet-1.6.0/license.txt -
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    install_requires=['sagemaker-inference>=1.1.0,<=1.5.2', 'retrying==1.3.3'],
+    install_requires=['sagemaker-inference>=1.1.0,<=1.5.7', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.62.0', 'docker-compose', 'mxnet==1.7.0.post1', 'awslogs',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    install_requires=['sagemaker-inference>=1.1.0,<=1.5.7', 'retrying==1.3.3'],
+    install_requires=['sagemaker-inference>=1.1.0,<=1.5.6', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.62.0', 'docker-compose', 'mxnet==1.7.0.post1', 'awslogs',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    install_requires=['sagemaker-inference>=1.1.0,<=1.5.6', 'retrying==1.3.3'],
+    install_requires=['sagemaker-inference>=1.1.0,<=1.5.2', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.62.0', 'docker-compose', 'mxnet==1.7.0.post1', 'awslogs',

--- a/src/sagemaker_mxnet_serving_container/handler_service.py
+++ b/src/sagemaker_mxnet_serving_container/handler_service.py
@@ -38,7 +38,7 @@ class HandlerService(DefaultHandlerService):
         - The ``handle`` method is invoked for all incoming inference requests to the model server.
         - The ``initialize`` method is invoked at model server start up.
 
-    Based on: https://github.com/awslabs/mxnet-model-server/blob/master/docs/custom_service.md
+    Based on: https://github.com/awslabs/multi-model-server/blob/master/docs/custom_service.md
 
     """
     def __init__(self):

--- a/test/container/1.7.0/Dockerfile.mxnet.cpu
+++ b/test/container/1.7.0/Dockerfile.mxnet.cpu
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
-ARG MMS_VERSION=1.0.8
+ARG MMS_VERSION=1.1.5
 
 ENV SAGEMAKER_SERVING_MODULE sagemaker_mxnet_serving_container.serving:main
 ENV TEMP=/home/model-server/tmp
@@ -45,7 +45,7 @@ RUN cd /tmp && \
 
 RUN pip install --upgrade pip
 RUN pip install --no-cache mxnet==1.7.0.post1 \
-    mxnet-model-server==$MMS_VERSION
+    multi-model-server==$MMS_VERSION
 
 COPY dist/sagemaker_mxnet_inference-*.tar.gz /sagemaker_mxnet_inference.tar.gz
 RUN pip install --no-cache-dir /sagemaker_mxnet_inference.tar.gz && \
@@ -66,4 +66,4 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The inference toolkit increases the timeout that the model server waits up to 10 minutes. This change will consume version 1.5.7 which introduces this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
