### PR TITLE
fix: stop pinning sagemaker-inference toolkit version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    install_requires=['sagemaker-inference>=1.1.0,<=1.5.7', 'retrying==1.3.3'],
+    install_requires=['sagemaker-inference>=1.5.0', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.62.0', 'docker-compose', 'mxnet==1.7.0.post1', 'awslogs',


### PR DESCRIPTION
...remove upper bound to version specification in setup.py

*Issue #, if available:*

*Description of changes:*
Remove upper bound to version specification of sagemaker-inference in setup.py, to allow upgrades to be pulled in automatically.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
